### PR TITLE
Add "console" attribute to hardware structure

### DIFF
--- a/quattor/schema.pan
+++ b/quattor/schema.pan
@@ -162,6 +162,65 @@ type structure_cards = {
 } with is_valid_card_ports (SELF);
 
 ############################################################
+# structure_serial_console
+############################################################
+type structure_serial_console = {
+    include structure_annotation
+    "parity" ? string with match(SELF, "^(n|p)$")
+    "speed"  ? long
+    "unit"   ? long
+    "word"   ? long(7..8)
+};
+
+############################################################
+# structure_telnet_console
+############################################################
+type structure_telnet_console = {
+    "port" : long = 23
+    "fqdn" : string
+};
+############################################################
+# structure_ipmi_console
+############################################################
+type structure_ipmi_console = {
+    "fqdn"      ? string
+    "hwaddr"    : type_hwaddr
+};
+############################################################
+# structure_ssh_console
+############################################################
+type structure_ssh_console = {
+    "fqdn"      ? string
+    "hwaddr"    : type_hwaddr
+};
+############################################################
+# structure_bmc_console
+############################################################
+type structure_bmc_console = {
+    "fqdn"      ? string
+    "hwaddr"    : type_hwaddr
+};
+############################################################
+# structure_dpc_console
+############################################################
+type structure_dpc_console = {
+    "fqdn"      ? string
+    "hwaddr"    : type_hwaddr
+};
+############################################################
+# structure_console
+############################################################
+type structure_console = extensible {
+    "serial" ? structure_serial_console
+    "telnet" ? structure_telnet_console
+    "ssh"    ? structure_ssh_console
+    "ipmi"   ? structure_ipmi_console
+    "dpc"    ? structure_dpc_console
+    "bmc"    ? structure_dpc_console
+    "preferred" : string[]
+};
+
+############################################################
 # structure_hardware
 ############################################################
 type structure_hardware = {
@@ -171,13 +230,12 @@ type structure_hardware = {
     "cards"        ? structure_cards
     "rack"	   ? structure_rack
     # Obsolete field, use the appropriate "cards" sub-field instead!!
-    "harddisks"     ? structure_raidport{}
-    
+    "harddisks"    ? structure_raidport{}
+    "console"      ? structure_console
 };
 
 # network schema defined within component area
 include {"components/network/core-schema"};
-
 
 
 ############################################################


### PR DESCRIPTION
Allow the modelling of different types of OOB access to the hardware,
including support for serial consoles as well as various types of
network-based access.

There is a PR open to add code to ncm-grub that optionally takes advantage of this new field.

THE FOLLOWING DISCLAIMER APPLIES TO ALL SOFTWARE CODE
AND OTHER MATERIALS CONTRIBUTED IN CONNECTION WITH THIS
SOFTWARE:

THIS SOFTWARE IS LICENSED BY THE COPYRIGHT HOLDERS AND
CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
PARTICULAR PURPOSE AND ANY WARRANTY OF NON-
INFRINGEMENT, ARE DISCLAIMED.

IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS
BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
DAMAGE. THIS SOFTWARE MAY BE REDISTRIBUTED TO OTHERS
ONLY BY EFFECTIVELY USING THIS OR ANOTHER EQUIVALENT
DISCLAIMER AS WELL AS ANY OTHER LICENSE TERMS THAT MAY
APPLY.
