### PR TITLE
correct prefix for packages

### DIFF
--- a/components/spma/config-rpm.pan
+++ b/components/spma/config-rpm.pan
@@ -20,10 +20,11 @@ unique template components/spma/config-rpm;
 # Set prefix to root of component configuration.
 prefix '/software/components/spma';
 "/software/groups" ?= nlist();
-
-# Package to install
-'packages' = pkg_repl("ncm-spma", "14.4.0-rc3_SNAPSHOT20140507141729", "noarch");
-
 'packager' = 'yum';
 'register_change' ?= list("/software/packages",
                           "/software/repositories");
+# Package to install
+prefix '/software';
+'packages' = pkg_repl("ncm-spma", "14.4.0-rc3_SNAPSHOT20140507141729", "noarch");
+
+


### PR DESCRIPTION
packages are found under /software, and not under /software/components/spma. This causes compilation falures. I have changed the order to match this.
