### PR TITLE
Remove support for AII v2 (AII_V2_INSTALL variable)

### DIFF
--- a/quattor/client/rpms.pan
+++ b/quattor/client/rpms.pan
@@ -5,10 +5,6 @@
 
 unique template quattor/client/rpms;
 
-# Set to true if installing the machine with AII v2 (pre-YUM)
-variable AII_V2_INSTALL ?= false;
-
-
 include { 'quattor/client/version' };
 
 # Default version of packages in the selected OS
@@ -16,6 +12,7 @@ include { 'rpms/package_default_versions' };
 
 
 '/software/packages' = {
+    # OS-provided required packages
     # Part of the OS, installed by Anaconda as part of the base packages
     if ( is_defined(OS_VERSION_PARAMS['majorversion']) && (OS_VERSION_PARAMS['majorversion'] == '5') ) {
       SELF[escape('yum-priorities')] = nlist();
@@ -27,34 +24,14 @@ include { 'rpms/package_default_versions' };
     if ( OS_VERSION_PARAMS['majorversion'] == '5' ) {
       SELF[escape('python-elementtree')] = nlist();
     };
-    if ( AII_V2_INSTALL ) {
-        # Yum
-        # Quattor
-        pkg_repl('perl-Set-Scalar');
-        pkg_repl('perl-common-sense');
-        pkg_repl('perl-JSON-XS');
-        pkg_repl('ncm-spma', QUATTOR_PACKAGES_VERSION, 'noarch');
-        pkg_repl('ccm', QUATTOR_PACKAGES_VERSION, 'noarch');
-        pkg_repl('cdp-listend', QUATTOR_PACKAGES_VERSION, 'noarch');
-        # Dependencies
-        pkg_repl('perl-LC', QUATTOR_PACKAGES_VERSION, 'noarch');
-        pkg_repl('perl-Proc-ProcessTable');
-        pkg_repl('perl-CAF', QUATTOR_PACKAGES_VERSION, 'noarch');
-        # NCM components.
-        pkg_repl('ncm-cdispd', QUATTOR_PACKAGES_VERSION, 'noarch');
-        pkg_repl('ncm-ncd', QUATTOR_PACKAGES_VERSION, 'noarch');
-        pkg_repl('ncm-query', QUATTOR_PACKAGES_VERSION, 'noarch');
 
-      } else {
-        # Quattor
-        SELF[escape('ncm-spma')] = nlist();
-        SELF[escape('ccm')] = nlist();
-        SELF[escape('cdp-listend')] = nlist();
-        SELF[escape('ncm-cdispd')] = nlist();
-        SELF[escape('ncm-ncd')] = nlist();
-        SELF[escape('ncm-query')] = nlist();
+    # Quattor
+    SELF[escape('ncm-spma')] = nlist();
+    SELF[escape('ccm')] = nlist();
+    SELF[escape('cdp-listend')] = nlist();
+    SELF[escape('ncm-cdispd')] = nlist();
+    SELF[escape('ncm-ncd')] = nlist();
+    SELF[escape('ncm-query')] = nlist();
       
-      };
-
-      SELF;
+    SELF;
 };


### PR DESCRIPTION
No longer needed as current AII supports both installing YUM and non YUM machines. Avoid side effect of letting it defined with the new AII.
