### PR TITLE
Restore addition python-elementtree on SL5

### DIFF
--- a/quattor/client/rpms.pan
+++ b/quattor/client/rpms.pan
@@ -12,7 +12,11 @@ include { 'rpms/package_default_versions' };
 
 
 '/software/packages' = {
-    # OS-provided required packages
+    # python-elementtree is required by YUM on SL5 but not listed as a dependency
+    # of any other package
+    if ( OS_VERSION_PARAMS['majorversion'] == '5' ) {
+      SELF[escape('python-elementtree')] = nlist();
+    };
 
     # Quattor
     SELF[escape('cdp-listend')] = nlist();


### PR DESCRIPTION
- required dependency for YUM (or one of its plugin) not listed as an explicit dependency

Fixes an issue found during 15.4.0-rc4 (https://github.com/quattor/release/issues/96) introduced by recent cleanups in `quattor/client\rpms.pan`.