### PR TITLE
Make system kernel version optional

### DIFF
--- a/quattor/types/system.pan
+++ b/quattor/types/system.pan
@@ -46,7 +46,7 @@ type structure_system = {
     "filesystems"   ? structure_filesystem[]
     "blockdevices" ? structure_blockdevices
     "glite"         ? structure_glite
-    "kernel"        : structure_kernel
+    "kernel"        ? structure_kernel
     "lcg"           ? structure_lcg
     "network"       : structure_network
     # TODO: monitoring-related structures should go elsewhere. 


### PR DESCRIPTION
I'm not sure why it was required, we certainly have no problems on systems where it is not set.