### PR TITLE
Add boolean hyperthreading for structure cpu.

### DIFF
--- a/quattor/types/hardware.pan
+++ b/quattor/types/hardware.pan
@@ -23,6 +23,7 @@ type structure_cpu = {
     "speed"  : long # "CPU clock speed in MHz"
     # Number of cores on each CPU chip, defaults to 1.
     "cores" : long(1..) = 1
+    "hyperthreading" : boolean = false
 };
 
 


### PR DESCRIPTION
Hi,

 I'm a new quattor user from T2_BE_IIHE, this is my first pull request, so I apologize beforehand if I'm doing something wrong !

I'd like to make changes to how slots are calculated for hyperthreaded CPUs. 
This merge request just adds a new field to the cpu structure. It will allow us to compute the number of logical cores for CPUs with hyperthreading. It defaults to false.

Cheers
Romain
