### PR TITLE
Add function to validate that paths in dict keys are valid files

### DIFF
--- a/quattor/functions/validation.pan
+++ b/quattor/functions/validation.pan
@@ -145,3 +145,20 @@ function is_valid_card_ports = {
      };
      true;
 };
+
+
+@documentation{
+    desc = Checks keys of a dict are valid absolute paths to files (not directories), prints errors for all invalid paths
+}
+function valid_absolute_file_paths = {
+    foreach (k; v; ARGV[0]) {
+        path = unescape(k);
+        if (match(path, '/$')) {
+            error(format('Path "%s" does not refer to a file, it has an invalid trailing slash', path));
+        };
+        if (match(path, '^[^/]')) {
+            error(format('Path "%s" is not absolute, leading slash is missing', path));
+        };
+    };
+    true;
+};


### PR DESCRIPTION
To be used by components such as filecopy and metaconfig.

See quattor/configuration-modules-core#628