### PR TITLE
LV: add support for lvmcache in schema

### DIFF
--- a/quattor/blockdevices.pan
+++ b/quattor/blockdevices.pan
@@ -61,7 +61,7 @@ type blockdevices_md_type = {
 };
 
 @documentation{
-    lvm cache volume and mode\
+    lvm cache volume and mode
 }
 type blockdevices_logicalvolumes_cache_type = {
     "cache_lv" : lv_string
@@ -77,7 +77,8 @@ type blockdevices_logicalvolumes_type = {
     "stripe_size" ? long # Size of the stripe. If not used, no striping
     "devices" ? blockdev_string[]
     "cache" ? blockdevices_logicalvolumes_cache_type
-    "type" ? string with match (SELF,'^(cache(-pool)|error|linear|mirror|raid[14]|raid5_(la|ls|ra|rs)|raid6_(nc|nr|zr)|raid10|snapshot|striped|thin(-pool)?|zero)$)
+    "type" ? string with match (SELF,
+        '^(cache(-pool)|error|linear|mirror|raid[14]|raid5_(la|ls|ra|rs)|raid6_(nc|nr|zr)|raid10|snapshot|striped|thin(-pool)?|zero)$')
 };
     
 type blockdevices_lvm_type = {

--- a/quattor/blockdevices.pan
+++ b/quattor/blockdevices.pan
@@ -18,6 +18,9 @@ type vg_string = string with exists ("/system/blockdevices/volume_groups/" + SEL
     || error (SELF + " must be a path relative to "
               + "/system/blockdevices/volume_groups");
 
+type lv_string = string with exists ("/system/blockdevices/logical_volumes/" + SELF)
+    || error (SELF + " must be a path relative to "
+              + "/system/blockdevices/logical_volumes");
 @documentation{
     parted partition flags (from "info parted")
 }
@@ -58,12 +61,23 @@ type blockdevices_md_type = {
 };
 
 @documentation{
+    lvm cache volume and mode\
+}
+type blockdevices_logicalvolumes_cache_type = {
+    "cache_lv" : lv_string
+    "cachemode" ? string with match(SELF, "^(writethrough|writeback)$")
+};
+
+@documentation{
     LVM
 }
 type blockdevices_logicalvolumes_type = {
     "size" ? long # "Size in MB"
     "volume_group" : vg_string
     "stripe_size" ? long # Size of the stripe. If not used, no striping
+    "devices" ? blockdev_string[]
+    "cache" ? blockdevices_logicalvolumes_cache_type
+    "type" ? string with match (SELF,'^(cache(-pool)|error|linear|mirror|raid[14]|raid5_(la|ls|ra|rs)|raid6_(nc|nr|zr)|raid10|snapshot|striped|thin(-pool)?|zero)$)
 };
     
 type blockdevices_lvm_type = {


### PR DESCRIPTION
Depends on https://github.com/quattor/ncm-lib-blockdevices/pull/61