### PR TITLE
adding HW tags

### DIFF
--- a/quattor/types/annotation.pan
+++ b/quattor/types/annotation.pan
@@ -19,4 +19,5 @@ type structure_annotation = {
    "lang"         ? string # "language of the product"
    "power"        ? long   # "power in watts"
    "location"     ? string # "location of the hardware"
+   "tags"         ? nlist  # "user defined HW tags"
 };

--- a/quattor/types/annotation.pan
+++ b/quattor/types/annotation.pan
@@ -19,5 +19,5 @@ type structure_annotation = {
    "lang"         ? string # "language of the product"
    "power"        ? long   # "power in watts"
    "location"     ? string # "location of the hardware"
-   "tags"         ? nlist  # "user defined HW tags"
+   "tags"         ? dict   # "user defined HW tags"
 };


### PR DESCRIPTION
Very small change proposed. This is just to request the possibility to have user defined HW tags by adding a "tags" nlist to annotation.pan. We've found useful at LLR to have the possibility to have some suitably defined tags associated to some hardware profile and use them to trigger some configurations/features. 
 