### PR TITLE
Add new template for legacy types

### DIFF
--- a/pan/legacy.pan
+++ b/pan/legacy.pan
@@ -1,0 +1,3 @@
+declaration template pan/legacy;
+
+type legacy_binary_affirmation_string = string with match(SELF, "^(yes|no)$");

--- a/pan/types.pan
+++ b/pan/types.pan
@@ -31,6 +31,7 @@ Data type and function definitions for the following basic types:
 
 declaration template pan/types;
 
+include 'pan/legacy';
 
 @documentation{
 This type implements a date/time format consistent with


### PR DESCRIPTION
Types in here should be collected to be phased out of use.
The first is the infamous non-boolean yesnostring used by several component with different names.