### PR TITLE
Allow thread count of CPU to be specified

### DIFF
--- a/quattor/types/hardware.pan
+++ b/quattor/types/hardware.pan
@@ -26,7 +26,7 @@ type structure_cpu = {
     "cores" : long(1..) = 1
     @{ desc = Number of execution threads on each CPU chip, e.g. a hyperthreaded eight core chip would have 16 threads }
     "max_threads" ? long(1..)
-    "hyperthreading" : boolean = false
+    "hyperthreading" : boolean = false with {deprecated(0, 'The hyperthreading cpu property has been deprecated, please migrate to max_threads'); true;}
 };
 
 

--- a/quattor/types/hardware.pan
+++ b/quattor/types/hardware.pan
@@ -23,6 +23,7 @@ type structure_cpu = {
     "speed"  : long # "CPU clock speed in MHz"
     # Number of cores on each CPU chip, defaults to 1.
     "cores" : long(1..) = 1
+    "max_threads" ? long(1..)
     "hyperthreading" : boolean = false
 };
 

--- a/quattor/types/hardware.pan
+++ b/quattor/types/hardware.pan
@@ -20,9 +20,11 @@ type structure_ram = {
 }
 type structure_cpu = {
     include structure_annotation
-    "speed"  : long # "CPU clock speed in MHz"
-    # Number of cores on each CPU chip, defaults to 1.
+    @{ desc = CPU clock speed in MHz }
+    "speed" : long
+    @{ desc = Number of cores on each CPU chip }
     "cores" : long(1..) = 1
+    @{ desc = Number of execution threads on each CPU chip, e.g. a hyperthreaded eight core chip would have 16 threads }
     "max_threads" ? long(1..)
     "hyperthreading" : boolean = false
 };


### PR DESCRIPTION
Following on from #94 and related to quattor/template-library-standard#66, it would be nice to be able to record the physical threadcount of CPUs.