### PR TITLE
Add a transitional type to allow components to migrate to real booleans

### DIFF
--- a/pan/legacy.pan
+++ b/pan/legacy.pan
@@ -1,3 +1,15 @@
 declaration template pan/legacy;
 
 type legacy_binary_affirmation_string = string with match(SELF, "^(yes|no)$");
+
+function is_yes_no_true_false = {
+    v = ARGV[0];
+    if (is_boolean(v)) return(true);
+    if (is_string(v) && match(v, "^(yes|no)$")) {
+        deprecated(0, 'Legacy yes/no value in use, please migrate to true/false.');
+        return(true);
+    };
+    false;
+};
+
+type transitional_yes_no_true_false = property with is_yes_no_true_false(SELF);

--- a/pan/legacy.pan
+++ b/pan/legacy.pan
@@ -1,7 +1,20 @@
+@documentation{
+Legacy and transitional type definitions
+
+Should not be used for any new components, they are collected here to aid transition to newer types.
+}
 declaration template pan/legacy;
 
+@documentation{
+Common type to replace all variants of yes/no pseudo boolean strings throughout components
+}
 type legacy_binary_affirmation_string = string with match(SELF, "^(yes|no)$");
 
+@documentation{
+Validate a property to either be a boolean or a yes/no string
+
+Used to implement transitional_yes_no_true_false
+}
 function is_yes_no_true_false = {
     v = ARGV[0];
     if (is_boolean(v)) return(true);
@@ -12,4 +25,10 @@ function is_yes_no_true_false = {
     false;
 };
 
+@documentation{
+Transitional type to allow components to cleanly migrate properties from yes/no strings to booleans
+
+No components shall use this type until it has been made compatible with real booleans
+No component shall use this type for more than a single release
+}
 type transitional_yes_no_true_false = property with is_yes_no_true_false(SELF);


### PR DESCRIPTION
For the 16.8 cycle I plan to migrate as many properties of as many components as possible from using `legacy_binary_affirmation_string` to `transitional_yes_no_true_false`, then migrate them to `boolean` in a following release cycle.