### PR TITLE
Throw error if short hostname is used as a network_name

### DIFF
--- a/pan/types.pan
+++ b/pan/types.pan
@@ -914,10 +914,9 @@ function is_network_name = {
     # Is it a FQDN or an IP (v4 or v6) address?
     if (is_hostname(ARGV[0])) return(true);
 
-    # Is it a deprecated short-form hostname?
+    # Is it a short-form hostname?
     if (is_shorthostname(ARGV[0])) {
-        deprecated(0, "Short hostnames are deprecated as valid network_names.");
-        return(true);
+        error("Short hostname is not a valid network_name.");
     };
 
     # How about a valid TLD?


### PR DESCRIPTION
They are not valid, but we have allowed them with a deprecation warning since the 15.8 release.

Closes #78.