### PR TITLE
aii-opennebula: Fix default values of global variables

### DIFF
--- a/quattor/aii/opennebula/default.pan
+++ b/quattor/aii/opennebula/default.pan
@@ -3,9 +3,9 @@ unique template quattor/aii/opennebula/default;
 include 'quattor/aii/opennebula/schema';
 include 'quattor/aii/opennebula/functions';
 
-#  undef are set via schema default
-variable OPENNEBULA_AII_FORCE ?= undef; 
-variable OPENNEBULA_AII_ONHOLD ?= undef;
+# null values are set by schema defaults
+variable OPENNEBULA_AII_FORCE ?= null;
+variable OPENNEBULA_AII_ONHOLD ?= null;
 variable OPENNEBULA_AII_FORCE_REMOVE ?= false;
 
 variable MAC_PREFIX ?= '02:00';

--- a/quattor/aii/opennebula/default.pan
+++ b/quattor/aii/opennebula/default.pan
@@ -10,64 +10,42 @@ variable OPENNEBULA_AII_FORCE_REMOVE ?= false;
 
 variable MAC_PREFIX ?= '02:00';
 
-"/system/aii/hooks/configure/" = {
-    append(nlist(
-        'module', OPENNEBULA_AII_MODULE_NAME,
-
-        "image", OPENNEBULA_AII_FORCE,
-        "template", OPENNEBULA_AII_FORCE,
-        ));
-
-    SELF;
-};
+"/system/aii/hooks/configure/" = append(SELF, dict(
+    'module', OPENNEBULA_AII_MODULE_NAME,
+    "image", OPENNEBULA_AII_FORCE,
+    "template", OPENNEBULA_AII_FORCE,
+));
 
 bind "/system/aii/hooks" = nlist with validate_aii_opennebula_hooks('configure');
 
-"/system/aii/hooks/install/" = {
-    append(nlist(
-        'module', OPENNEBULA_AII_MODULE_NAME,
-
-        "vm", OPENNEBULA_AII_FORCE,
-        "onhold", OPENNEBULA_AII_ONHOLD,
-        ));
-
-    SELF;
-};
+"/system/aii/hooks/install/" = append(SELF, dict(
+    'module', OPENNEBULA_AII_MODULE_NAME,
+    "vm", OPENNEBULA_AII_FORCE,
+    "onhold", OPENNEBULA_AII_ONHOLD,
+));
 
 bind "/system/aii/hooks" = nlist with validate_aii_opennebula_hooks('install');
 
 # last is not so important here
-"/system/aii/hooks/remove/" = {
-    append(nlist(
-        'module', OPENNEBULA_AII_MODULE_NAME,
-
-        "image", OPENNEBULA_AII_FORCE_REMOVE,
-        "template", OPENNEBULA_AII_FORCE_REMOVE,
-        "vm", OPENNEBULA_AII_FORCE_REMOVE,
-        ));
-
-    SELF;
-};
+"/system/aii/hooks/remove/" = append(SELF, dict(
+    'module', OPENNEBULA_AII_MODULE_NAME,
+    "image", OPENNEBULA_AII_FORCE_REMOVE,
+    "template", OPENNEBULA_AII_FORCE_REMOVE,
+    "vm", OPENNEBULA_AII_FORCE_REMOVE,
+));
 
 bind "/system/aii/hooks" = nlist with validate_aii_opennebula_hooks('remove');
 
-
 # Enable ACPI daemon
-"/system/aii/hooks/post_reboot/" = {
-    append(nlist(
-        'module', OPENNEBULA_AII_MODULE_NAME
-        ));
-
-    SELF;
-};
+"/system/aii/hooks/post_reboot/" = append(SELF, dict(
+    'module', OPENNEBULA_AII_MODULE_NAME
+));
 
 bind "/system/aii/hooks" = nlist with validate_aii_opennebula_hooks('post_reboot');
 
 # If required replace VM hwaddr using OpenNebula fashion
-"/hardware/cards/nic" = {
-    if (exists(OPENNEBULA_AII_REPLACE_MAC) && exists(MAC_PREFIX)) {
-        opennebula_replace_vm_mac(MAC_PREFIX);
-    } else {
-        SELF;
-    };
+"/hardware/cards/nic" = if (exists(OPENNEBULA_AII_REPLACE_MAC) && exists(MAC_PREFIX)) {
+    opennebula_replace_vm_mac(MAC_PREFIX);
+} else {
+    SELF;
 };


### PR DESCRIPTION
Replace undef with null to allow the schema to apply defaults as the comment suggests

This fixes the test errors seen in #110, #120 and #121.

Also did some re-factoring, because the code made me feel sad.