### PR TITLE
Upgrade default panc version to 10.3-1

### DIFF
--- a/quattor/client/pan_compiler.pan
+++ b/quattor/client/pan_compiler.pan
@@ -3,5 +3,13 @@
 
 unique template quattor/client/pan_compiler;
 
-'/software/packages' = pkg_repl('panc','10.2-1','noarch');
+@{
+desc = Pan compiler version to install
+values = string (version number)
+default = 10.3-1
+required = no
+}
+variable PANC_DEFAULT_VERSION ?= '10.3-1';
+
+'/software/packages' = pkg_repl('panc',PANC_DEFAULT_VERSION,'noarch');
 


### PR DESCRIPTION
This PR also make the default site-customizable through `PANC_DEFAULT_VERSION`.

10.3-1 contains an important fix related to possible modification of a global variable from a foreach in a DML (attached to another variable). It would be important IMO to set it as the new panc baseline.

Tests made on the template library showed no problems triggered by this fix.

As this is not urgent, I propose to set this new baseline in 16.12.