### PR TITLE
Make CPU hyperthreading optional and remove default value

### DIFF
--- a/quattor/types/hardware.pan
+++ b/quattor/types/hardware.pan
@@ -26,7 +26,7 @@ type structure_cpu = {
     "cores" : long(1..) = 1
     @{ desc = Number of execution threads on each CPU chip, e.g. a hyperthreaded eight core chip would have 16 threads }
     "max_threads" ? long(1..)
-    "hyperthreading" : boolean = false with {deprecated(0, 'The hyperthreading cpu property has been deprecated, please migrate to max_threads'); true;}
+    "hyperthreading" ? boolean with {deprecated(0, 'The hyperthreading cpu property has been deprecated, please migrate to max_threads'); true;}
 };
 
 


### PR DESCRIPTION
This is the next step in deprecation towards removal and will ensure that only sites actively setting the parameter will receive deprecation warnings.