### PR TITLE
Add structures to model operating system information

### DIFF
--- a/pan/types.pan
+++ b/pan/types.pan
@@ -990,3 +990,8 @@ type valid_interface = string with {
     };
     false;
 };
+
+@documentation{
+    desc = CPU architectures understood by Quattor
+}
+type cpu_architecture = string with match (SELF, '^(i386|ia64|x86_64|sparc|aarch64|ppc64(le)?)$');

--- a/quattor/types/annotation.pan
+++ b/quattor/types/annotation.pan
@@ -5,18 +5,18 @@ declaration template quattor/types/annotation;
     optional hardware specific information
 }
 type structure_annotation = {
-   "name"         ? string # "product name"
-   "type"         ? string # "product type"
-   "model"        ? string # "product model"
-   "manufacturer" ? string # "manufacturer name"
-   "vendor"       ? string # "vendor name"
-   "version"      ? string # "product version"
-   "chipset"      ? string # "product chipset"
-   "serialnumber" ? string # "product serialnumber"
-   "arch"         ? string # "product architecture" i386, amd64, m68k, ...
-   "bus"          ? string # "bus of peripheral"
-   "clock"        ? long   # "clock of peripheral"
-   "lang"         ? string # "language of the product"
-   "power"        ? long   # "power in watts"
-   "location"     ? string # "location of the hardware"
+    "name"         ? string # "product name"
+    "type"         ? string # "product type"
+    "model"        ? string # "product model"
+    "manufacturer" ? string # "manufacturer name"
+    "vendor"       ? string # "vendor name"
+    "version"      ? string # "product version"
+    "chipset"      ? string # "product chipset"
+    "serialnumber" ? string # "product serialnumber"
+    "arch"         ? string # "product architecture" i386, amd64, m68k, ...
+    "bus"          ? string # "bus of peripheral"
+    "clock"        ? long   # "clock of peripheral"
+    "lang"         ? string # "language of the product"
+    "power"        ? long   # "power in watts"
+    "location"     ? string # "location of the hardware"
 };

--- a/quattor/types/annotation.pan
+++ b/quattor/types/annotation.pan
@@ -13,7 +13,7 @@ type structure_annotation = {
     "version"      ? string # "product version"
     "chipset"      ? string # "product chipset"
     "serialnumber" ? string # "product serialnumber"
-    "arch"         ? string # "product architecture" i386, amd64, m68k, ...
+    "arch"         ? cpu_architecture # "product architecture" i386, amd64, m68k, ...
     "bus"          ? string # "bus of peripheral"
     "clock"        ? long   # "clock of peripheral"
     "lang"         ? string # "language of the product"

--- a/quattor/types/aquilon.pan
+++ b/quattor/types/aquilon.pan
@@ -41,7 +41,6 @@ type structure_archetype = {
     "name"          : string # e.g. "aquilon"
     @{ Details of operating system as defined by aquilon broker }
     "os"            ? structure_archetype_os
-    "model"         ? string # e.g. "4.0.1-x86_64"
     "filesystem-layout" ? string with if_exists("archetype/filesystem-layouts/" + SELF) != ""
     "archlist"      ? string[] # e.g. fs sysname list for model,
                                # "x86_64.linux.2.6.glibc.2.3", "amd64.linux.2.4.glibc.2.3", ...

--- a/quattor/types/aquilon.pan
+++ b/quattor/types/aquilon.pan
@@ -29,10 +29,18 @@ type structure_cluster = {
     "down_hosts_threshold" ? long(0..)
     "node_index" ? long(0..)
 };
- 
+
+type structure_archetype_os = {
+    @{ Name of OS (i.e. aq --osname or aqdb OperatingSystem.name) }
+    "name" : string
+    @{ Version of OS (i.e. aq --osversion or aqdb OperatingSystem.version) }
+    "version" : string
+};
+
 type structure_archetype = {
     "name"          : string # e.g. "aquilon"
-    "os"            ? string # e.g. "linux"
+    @{ Details of operating system as defined by aquilon broker }
+    "os"            ? structure_archetype_os
     "model"         ? string # e.g. "4.0.1-x86_64"
     "filesystem-layout" ? string with if_exists("archetype/filesystem-layouts/" + SELF) != ""
     "archlist"      ? string[] # e.g. fs sysname list for model,
@@ -115,7 +123,7 @@ type structure_security = {
     "class"         : string with if_exists("archetype/security/" + SELF) != ""
     "svcwhitelist"  ? list
 };
- 
+
 type structure_system_aquilon = {
     "advertise_status" ? boolean
     "archetype"     ? structure_archetype

--- a/quattor/types/os.pan
+++ b/quattor/types/os.pan
@@ -1,0 +1,31 @@
+@{
+    Types describing the operating system in use by a system
+}
+declaration template quattor/types/os;
+
+type structure_os_version = {
+    @{Descriptive form of version, e.g. 7x}
+    "name" : string
+    @{Major version number component, e.g. 7}
+    "major" ? long(0..)
+    @{Minor version number component}
+    "minor" ? long(0..)
+};
+
+type structure_os_distribution = {
+    @{Distribution name, e.g. sl}
+    "name" : string with match(SELF, '^((rh)?el|centos|sl)$')
+    @{Full descriptive name, e.g. Scientific Linux}
+    "description" ? string
+    @{Family that this distribution belongs to e.g. The family for "sl" would be "el"}
+    "family" ? string with match(SELF, '^el$')
+};
+
+type structure_os = {
+    @{OS distribution details}
+    "distribution" : structure_os_distribution
+    @{OS version details}
+    "version" : structure_os_version
+    @{Architecture of OS (may be different to system architecture)}
+    "architecture" : cpu_architecture
+};

--- a/quattor/types/system.pan
+++ b/quattor/types/system.pan
@@ -35,8 +35,7 @@ include 'quattor/types/hardware';
 
 type structure_system = {
     "aii"           ? structure_aii
-    "architecture"  ? string with match (SELF,'i386|ia64|x86_64|sparc')
-                                # "system architecture"
+    "architecture"  ? cpu_architecture # "system architecture"
     "cluster"       ? structure_cluster
     "edg"           ? structure_edg
     "enclosure"     ? structure_enclosure

--- a/quattor/types/system.pan
+++ b/quattor/types/system.pan
@@ -4,7 +4,7 @@ declaration template quattor/types/system;
     system-related structures
 }
 type structure_import = {
-    "source"     : string # with isURI(SELF)
+    "source"     : string
     "mountpoint" ? string with match(SELF, '^(/[a-zA-Z\_\d/]*|none|swap)$')
     "options"    ? string
 };
@@ -15,7 +15,8 @@ type structure_export = {
 };
 
 type structure_kernel = {
-    "version"   ? string # "kernel version to use (eg. 2.4.18-27.7.x.cernsmp)"
+    @{kernel version to use (eg. 2.4.18-27.7.x.cernsmp)}
+    "version"   ? string
 };
 
 type structure_oldname = {
@@ -36,24 +37,26 @@ include 'quattor/types/os';
 
 type structure_system = {
     "aii"           ? structure_aii
-    "architecture"  ? cpu_architecture # "system architecture"
+    @{CPU architecture of system.}
+    "architecture"  ? cpu_architecture
     "cluster"       ? structure_cluster
     "edg"           ? structure_edg
     "enclosure"     ? structure_enclosure
-    "filesystems"   ? structure_filesystem[] with filesystems_uniq_paths(SELF) # check for duplicate mountpoints or blockdevices
+    @{Filesystems to be configured. Mountpoints and blockdevices must be unique.}
+    "filesystems"   ? structure_filesystem[] with filesystems_uniq_paths(SELF)
     "blockdevices" ? structure_blockdevices
     "glite"         ? structure_glite
     "kernel"        : structure_kernel
     "lcg"           ? structure_lcg
     "network"       : structure_network
-    # Monitoring-related schemas should handle the bind to this path when they are included
+    @{Monitoring-related schemas should handle the bind to this path when they are included.}
     "monitoring"    ? dict
     "oldnames"      ? structure_oldname[]
     "os" ? structure_os
     "rootmail"      : type_email
     "siterelease"   ? string
-    "state"         ? string with match (SELF,
-        '^(production|standby|test|development|onloan)$') # "production|out-of-production|test|development|onloan"
+    @{Current state of system, one of: production, out-of-production, test, development, onloan.}
+    "state"         ? string with match (SELF, '^(production|standby|test|development|onloan)$')
     "vo"            ? structure_vo{}
     include structure_system_aquilon
 };

--- a/quattor/types/system.pan
+++ b/quattor/types/system.pan
@@ -32,6 +32,7 @@ include 'quattor/types/aii';
 include 'quattor/types/aquilon';
 include 'quattor/types/grid';
 include 'quattor/types/hardware';
+include 'quattor/types/os';
 
 type structure_system = {
     "aii"           ? structure_aii
@@ -48,6 +49,7 @@ type structure_system = {
     # Monitoring-related schemas should handle the bind to this path when they are included
     "monitoring"    ? dict
     "oldnames"      ? structure_oldname[]
+    "os" ? structure_os
     "rootmail"      : type_email
     "siterelease"   ? string
     "state"         ? string with match (SELF,


### PR DESCRIPTION
We have systems that consume host profiles and need to extract information about the operating system, currently this is done with some nasty regex magic looking at values in locations such as `/system/aii/nbp/pxelinux/kernel` or in one case munging the contents of `/software/components/filecopy/services/{/etc/motd}/config`.

Since the actual information is present in aquilon and during compilation it can be trivially added to the profile.

The reference to OS in the schema at `/system/archetype/os` (defined in quattor/types/aquilon.pan) has been redefined to model the values (name and version) as managed by the aquilon broker.

The current plan is to populate `/system/os` from the `OS_VERSION_PARAMS` as used in template-library-standard, but this could in future be migrated to operating on `/system/os` directly.

Requires #143.