### PR TITLE
Add CPU architecture type definition

### DIFF
--- a/pan/types.pan
+++ b/pan/types.pan
@@ -990,3 +990,8 @@ type valid_interface = string with {
     };
     false;
 };
+
+@documentation{
+    desc = CPU architectures understood by Quattor
+}
+type cpu_architecture = string with match (SELF, '^(i386|ia64|x86_64|sparc|aarch64|ppc64(le)?)$');

--- a/quattor/types/annotation.pan
+++ b/quattor/types/annotation.pan
@@ -5,18 +5,18 @@ declaration template quattor/types/annotation;
     optional hardware specific information
 }
 type structure_annotation = {
-   "name"         ? string # "product name"
-   "type"         ? string # "product type"
-   "model"        ? string # "product model"
-   "manufacturer" ? string # "manufacturer name"
-   "vendor"       ? string # "vendor name"
-   "version"      ? string # "product version"
-   "chipset"      ? string # "product chipset"
-   "serialnumber" ? string # "product serialnumber"
-   "arch"         ? string # "product architecture" i386, amd64, m68k, ...
-   "bus"          ? string # "bus of peripheral"
-   "clock"        ? long   # "clock of peripheral"
-   "lang"         ? string # "language of the product"
-   "power"        ? long   # "power in watts"
-   "location"     ? string # "location of the hardware"
+    "name"         ? string # "product name"
+    "type"         ? string # "product type"
+    "model"        ? string # "product model"
+    "manufacturer" ? string # "manufacturer name"
+    "vendor"       ? string # "vendor name"
+    "version"      ? string # "product version"
+    "chipset"      ? string # "product chipset"
+    "serialnumber" ? string # "product serialnumber"
+    "arch"         ? string # "product architecture" i386, amd64, m68k, ...
+    "bus"          ? string # "bus of peripheral"
+    "clock"        ? long   # "clock of peripheral"
+    "lang"         ? string # "language of the product"
+    "power"        ? long   # "power in watts"
+    "location"     ? string # "location of the hardware"
 };

--- a/quattor/types/annotation.pan
+++ b/quattor/types/annotation.pan
@@ -13,7 +13,7 @@ type structure_annotation = {
     "version"      ? string # "product version"
     "chipset"      ? string # "product chipset"
     "serialnumber" ? string # "product serialnumber"
-    "arch"         ? string # "product architecture" i386, amd64, m68k, ...
+    "arch"         ? cpu_architecture # "product architecture" i386, amd64, m68k, ...
     "bus"          ? string # "bus of peripheral"
     "clock"        ? long   # "clock of peripheral"
     "lang"         ? string # "language of the product"

--- a/quattor/types/system.pan
+++ b/quattor/types/system.pan
@@ -35,8 +35,7 @@ include 'quattor/types/hardware';
 
 type structure_system = {
     "aii"           ? structure_aii
-    "architecture"  ? string with match (SELF,'i386|ia64|x86_64|sparc')
-                                # "system architecture"
+    "architecture"  ? cpu_architecture # "system architecture"
     "cluster"       ? structure_cluster
     "edg"           ? structure_edg
     "enclosure"     ? structure_enclosure


### PR DESCRIPTION
Related to #142 (implements validation of OS architecture).

Tagged as backwards incompatible as this will start to validate previously free-form fields.