### PR TITLE
client/rpms: allow to disable ncm-cdispd/cdp-listend installation

### DIFF
--- a/quattor/client/rpms.pan
+++ b/quattor/client/rpms.pan
@@ -5,21 +5,32 @@
 
 unique template quattor/client/rpms;
 
+@{
+descr = variable to enable installation of ncm-cdispd and ccm-listend
+values = boolean
+default = true
+required = No
+}
+variable QUATTOR_INSTALL_CDISPD ?= true;
+
 include 'quattor/client/version';
 
 '/software/packages' = {
     # python-elementtree is required by YUM on SL5 but not listed as a dependency
     # of any other package
     if ( OS_VERSION_PARAMS['majorversion'] == '5' ) {
-      pkg_repl('python-elementtree');
+        pkg_repl('python-elementtree');
     };
 
     # Quattor
-    pkg_repl('cdp-listend',QUATTOR_PACKAGES_VERSION,'noarch');
-    pkg_repl('ncm-cdispd',QUATTOR_PACKAGES_VERSION,'noarch');
     pkg_repl('ncm-ncd',QUATTOR_PACKAGES_VERSION,'noarch');
     pkg_repl('ncm-query',QUATTOR_PACKAGES_VERSION,'noarch');
     pkg_repl('ncm-spma',QUATTOR_PACKAGES_VERSION,'noarch');
+
+    if ( QUATTOR_INSTALL_CDISPD ) {
+        pkg_repl('cdp-listend',QUATTOR_PACKAGES_VERSION,'noarch');
+        pkg_repl('ncm-cdispd',QUATTOR_PACKAGES_VERSION,'noarch');
+    };
 
     SELF;
 };

--- a/quattor/client/rpms.pan
+++ b/quattor/client/rpms.pan
@@ -19,7 +19,7 @@ include 'quattor/client/version';
     # python-elementtree is required by YUM on SL5 but not listed as a dependency
     # of any other package
     if ( OS_VERSION_PARAMS['majorversion'] == '5' ) {
-        pkg_repl('python-elementtree');
+      pkg_repl('python-elementtree');
     };
 
     # Quattor

--- a/quattor/client/rpms.pan
+++ b/quattor/client/rpms.pan
@@ -28,8 +28,8 @@ include 'quattor/client/version';
     pkg_repl('ncm-spma',QUATTOR_PACKAGES_VERSION,'noarch');
 
     if ( QUATTOR_INSTALL_CDISPD ) {
-        pkg_repl('cdp-listend',QUATTOR_PACKAGES_VERSION,'noarch');
-        pkg_repl('ncm-cdispd',QUATTOR_PACKAGES_VERSION,'noarch');
+        pkg_repl('cdp-listend', QUATTOR_PACKAGES_VERSION, 'noarch');
+        pkg_repl('ncm-cdispd', QUATTOR_PACKAGES_VERSION, 'noarch');
     };
 
     SELF;


### PR DESCRIPTION
- Useful when Quattor is used to manage a VM image rather than a machine (in this case `ncm-ncd` is generally run manually and the profile name doesn't match a host name, making cdp notification useless)