### PR TITLE
Fix usage of onboot in copy_network_params function

### DIFF
--- a/quattor/functions/network.pan
+++ b/quattor/functions/network.pan
@@ -163,7 +163,7 @@ function ip_in_network = {
 
 @documentation{
     descr = Checks which subnet ipaddr is a member of and returns the corresponding subnet\
- parameters for netmask, gateway... 
+ parameters for netmask, gateway...
     arg = subnet list, a list of dict where the keys are all the properties supported\
  by structure_interface + 'subnet' which is the subnet number (result of applying the\
  mask to the address. `subnet` key is mandatory, 'netmask` defaults to 255.255.255.0.
@@ -214,5 +214,3 @@ function get_subnet_params = {
 
     error(format("No subnet matching address %s found", ipaddr));
 };
-
-

--- a/quattor/functions/network.pan
+++ b/quattor/functions/network.pan
@@ -83,7 +83,7 @@ function copy_network_params = {
             net_params = NETWORK_PARAMS;
         } else {
             net_params = dict();
-            net_params["onboot"] = "no";
+            net_params["onboot"] = false;
             net_params["bootproto"] = "dhcp";
         };
 


### PR DESCRIPTION
The update to the network component made backwards incompatible changes to the schema, in this case changing onboot from a string to a boolean. We should therefore not inject broken values into site configuration.