### PR TITLE
schema: Add structure for modelling hardware sensors

### DIFF
--- a/quattor/types/hardware.pan
+++ b/quattor/types/hardware.pan
@@ -3,6 +3,7 @@ declaration template quattor/types/hardware;
 include 'pan/types';
 include 'quattor/functions/hardware';
 include 'quattor/types/annotation';
+include 'quattor/types/sensors';
 include 'quattor/physdevices';
 
 @documentation{
@@ -261,6 +262,7 @@ type structure_hardware = {
     "sysloc"       ? structure_sysloc
     "nodename"     ? string
     "benchmarks" ? structure_benchmark
+    "sensors" ? structure_sensor_types
     @{Date at which the hardware support runs out.}
     "support"      ? type_isodate
     @{Date at which the hardware is procured.}

--- a/quattor/types/sensors.pan
+++ b/quattor/types/sensors.pan
@@ -1,0 +1,40 @@
+declaration template quattor/types/sensors;
+
+type structure_sensor = {
+    "name" : string with match(SELF, '^.+$')
+    "threshold" : long
+    "unit" : string with match(SELF, '^\S+$')
+};
+
+type structure_sensor_temperature = {
+    include structure_sensor
+    "unit" : string = "C"
+};
+
+type structure_sensor_voltage = {
+    include structure_sensor
+    "unit" : string = "V"
+};
+
+type structure_sensor_current = {
+    include structure_sensor
+    "unit" : string = "A"
+};
+
+type structure_sensor_power = {
+    include structure_sensor
+    "unit" : string = "W"
+};
+
+type structure_sensor_fanspeed = {
+    include structure_sensor
+    "unit" : string = "RPM"
+};
+
+type structure_sensor_types = {
+    "temperature" ? structure_sensor_temperature{}
+    "voltage" ? structure_sensor_voltage{}
+    "current" ? structure_sensor_current{}
+    "power" ? structure_sensor_power{}
+    "fanspeed" ? structure_sensor_fanspeed{}
+};


### PR DESCRIPTION
We use this at RAL to configure per-model thresholds for automatic shutdown.

The implementation details of how this data is used is left up to end users, including the interpretation of thresholds, units etc.