### PR TITLE
schema: Add resources to system structure

### DIFF
--- a/quattor/types/aquilon.pan
+++ b/quattor/types/aquilon.pan
@@ -19,8 +19,18 @@ type structure_virtual_machine = extensible {
     "hardware" : structure_hardware
 };
 
-type structure_resources = extensible {
-    "filesystem"    ? structure_fsdata[]
+type structure_resources = {
+    "application" ? list()
+    "auto_start_list" ? list()
+    "filesystem" ? structure_fsdata[]
+    "hostlink" ? list()
+    "intervention" ? list()
+    "reboot_iv" ? list()
+    "reboot_schedule" ? list()
+    "resourcegroup" ? list()
+    "service_address" ? list()
+    "share" ? list()
+    "system_list" ? list()
     "virtual_machine" ? structure_virtual_machine[]
 };
 

--- a/quattor/types/aquilon.pan
+++ b/quattor/types/aquilon.pan
@@ -14,8 +14,14 @@ type structure_fsdata = {
     "block_device_path" : string # No validation on this!
 };
 
+type structure_virtual_machine = extensible {
+    "name" : string
+    "hardware" : structure_hardware
+};
+
 type structure_resources = extensible {
     "filesystem"    ? structure_fsdata[]
+    "virtual_machine" ? structure_virtual_machine[]
 };
 
 type structure_cluster = {

--- a/quattor/types/system.pan
+++ b/quattor/types/system.pan
@@ -47,6 +47,7 @@ type structure_system = {
     @{Monitoring-related schemas should handle the bind to this path when they are included.}
     "monitoring"    ? dict
     "os" ? structure_os
+    "resources"     ? structure_resources
     "rootmail"      : type_email
     "siterelease"   ? string
     @{Current state of system, one of: production, out-of-production, test, development, onloan.}


### PR DESCRIPTION
The resources structure is used by the broker to model children of a host
(or cluster) for example virtual machines on a hypervisor.