### PR TITLE
pan types: Add type to model Linux capabilities

### DIFF
--- a/pan/types.pan
+++ b/pan/types.pan
@@ -995,3 +995,9 @@ type valid_interface = string with {
     desc = CPU architectures understood by Quattor
 }
 type cpu_architecture = string with match (SELF, '^(i386|ia64|x86_64|sparc|aarch64|ppc64(le)?)$');
+
+
+@documentation{
+    desc = Linux capabilities, see CAPABILITIES(7)
+}
+type linux_capability = string with match(SELF, '^CAP_[[:upper:]_]+$');


### PR DESCRIPTION
To be used in code that handles capabilities, e.g quattor/configuration-modules-core#1212.