### PR TITLE
Allow RAM to be modelled on GPU cards

### DIFF
--- a/quattor/types/hardware.pan
+++ b/quattor/types/hardware.pan
@@ -130,6 +130,7 @@ type structure_gpu = {
     include structure_annotation
     "driver" ? string
     "pci" ? structure_pci
+    "ram" ? structure_ram
 };
 
 @documentation{


### PR DESCRIPTION
Knowing the amount of RAM that a GPU has is very useful for making deployment and scheduling decisions, so provide the ability for it to be modelled.