### PR TITLE
Schema fixes required for Aquilon support

### DIFF
--- a/quattor/types/aquilon.pan
+++ b/quattor/types/aquilon.pan
@@ -49,8 +49,8 @@ type structure_cluster = {
 
 type structure_archetype = {
     "name"          : string # e.g. "aquilon"
-    "os"            ? string # e.g. "linux"
-    "model"         ? string # e.g. "4.0.1-x86_64"
+    "os"            : string # e.g. "linux"
+    "model"         : string # e.g. "4.0.1-x86_64"
     "filesystem-layout" ? string with if_exists("archetype/filesystem-layouts/" + SELF) != ""
     "archlist"      ? string[] # e.g. fs sysname list for model,
                                # "x86_64.linux.2.6.glibc.2.3", "amd64.linux.2.4.glibc.2.3", ...
@@ -105,7 +105,7 @@ type structure_personality = {
     "description"   ? string
     "class"         ? string with match(SELF, '(INFRASTRUCTURE|APPLICATION)')
     "users"         ? string[]
-    "systemgrn"     : string[]
+    "systemgrn"     ? string[]
     "escalation"    ? string
     "notifyrules"   ? string
     "notifyhours"   ? string

--- a/quattor/types/aquilon.pan
+++ b/quattor/types/aquilon.pan
@@ -50,6 +50,7 @@ type structure_cluster = {
 type structure_archetype = {
     "name"          : string # e.g. "aquilon"
     "os"            : string # e.g. "linux"
+    "os_lifecycle"  : string
     "model"         : string # e.g. "4.0.1-x86_64"
     "filesystem-layout" ? string with if_exists("archetype/filesystem-layouts/" + SELF) != ""
     "archlist"      ? string[] # e.g. fs sysname list for model,
@@ -120,9 +121,9 @@ type structure_personality = {
     # want anything else.
     "maintenance_threshold" ? long(0..100) = 50
     "backups"       ? string
-    "host_environment" ? string with match(SELF, "^(dev|qa|uat|prod|infra|legacy)$")
-    "owner_eon_id" ? long
-    "stage"         ? string
+    "host_environment" : string with match(SELF, "^(dev|qa|uat|prod|infra|legacy)$")
+    "owner_eon_id"  : long
+    "stage"         : string
     "esp"           ? structure_espinfo
 };
 
@@ -146,6 +147,8 @@ type structure_security = {
     "svcwhitelist"  ? list
 };
 
+# All resources in this structure muse be optional so that the
+# schema can be used by non Aquilon sites
 type structure_system_aquilon = {
     "advertise_status" ? boolean
     "archetype"     ? structure_archetype

--- a/quattor/types/aquilon/hardware.pan
+++ b/quattor/types/aquilon/hardware.pan
@@ -1,4 +1,4 @@
-# This template extends the base schema with Aquilon-provied resources
+# This template extends the base schema with Aquilon-provided resources
 
 declaration template quattor/types/aquilon/hardware;
 
@@ -30,8 +30,6 @@ type structure_sysloc = {
     "room"       : string
     "bunker"     ? string
     "region"     ? string
-    "dns_search_domains" ? string[]
-    "location"   ? string
 };
 
 # All the resources in this type must be optional for

--- a/quattor/types/aquilon/hardware.pan
+++ b/quattor/types/aquilon/hardware.pan
@@ -1,0 +1,43 @@
+# This template extends the base schema with Aquilon-provied resources
+
+declaration template quattor/types/aquilon/hardware;
+
+include 'pan/types';
+include 'quattor/functions/hardware';
+include 'quattor/types/annotation';
+include 'quattor/types/sensors';
+include 'quattor/physdevices';
+
+@documentation{
+    Rack definition
+}
+type structure_rack = {
+    "column" : string
+    "name"   : string
+    "room"   ? string
+    "row"    : string
+};
+
+@documentation{
+    system location definition
+}
+type structure_sysloc = {
+    "building"   : string
+    "campus"     ? string
+    "city"       : string
+    "country"    : string
+    "continent"  : string
+    "room"       : string
+    "bunker"     ? string
+    "region"     ? string
+    "dns_search_domains" ? string[]
+    "location"   ? string
+};
+
+# All the resources in this type must be optional for
+# the schema to remain usable by non-Aquilon users
+type structure_hardware_aquilon = {
+    "rack"       ? structure_rack
+    "sysloc"     ? structure_sysloc
+};
+

--- a/quattor/types/aquilon/system.pan
+++ b/quattor/types/aquilon/system.pan
@@ -1,4 +1,4 @@
-declaration template quattor/types/aquilon;
+declaration template quattor/types/aquilon/system;
 
 @documentation{
     aquilon-related structures

--- a/quattor/types/aquilon/system.pan
+++ b/quattor/types/aquilon/system.pan
@@ -1,3 +1,5 @@
+# This template extends the base schema with Aquilon-provided resources
+
 declaration template quattor/types/aquilon/system;
 
 @documentation{
@@ -47,8 +49,9 @@ type structure_cluster = {
     "max_hosts" ? long(0..)
 };
 
+@{ Details of operating system as defined by aquilon broker }
 type structure_archetype = {
-    "name"          : string # e.g. "aquilon"
+    "name"          ? string # e.g. "aquilon"
     "os"            : string # e.g. "linux"
     "os_lifecycle"  : string
     "model"         : string # e.g. "4.0.1-x86_64"
@@ -106,7 +109,6 @@ type structure_personality = {
     "description"   ? string
     "class"         ? string with match(SELF, '(INFRASTRUCTURE|APPLICATION)')
     "users"         ? string[]
-    "systemgrn"     ? string[]
     "escalation"    ? string
     "notifyrules"   ? string
     "notifyhours"   ? string
@@ -121,7 +123,7 @@ type structure_personality = {
     # want anything else.
     "maintenance_threshold" ? long(0..100) = 50
     "backups"       ? string
-    "host_environment" : string with match(SELF, "^(dev|qa|uat|prod|infra|legacy)$")
+    "host_environment" : string with match(SELF, "^(dev|qa|uat|prod)$")
     "owner_eon_id"  : long
     "stage"         : string
     "esp"           ? structure_espinfo

--- a/quattor/types/hardware.pan
+++ b/quattor/types/hardware.pan
@@ -2,6 +2,7 @@ declaration template quattor/types/hardware;
 
 include 'pan/types';
 include 'quattor/functions/hardware';
+include 'quattor/types/aquilon/hardware';
 include 'quattor/types/annotation';
 include 'quattor/types/sensors';
 include 'quattor/physdevices';
@@ -48,16 +49,6 @@ type structure_nic = {
     "boot"         ? boolean
     "maxspeed"     ? long
     "role"         ? string = ''
-};
-
-@documentation{
-    Rack definition
-}
-type structure_rack = {
-    "name" : string
-    "column" : string
-    "room" ? string
-    "row" : string
 };
 
 @documentation{
@@ -228,22 +219,6 @@ type structure_console = extensible {
 };
 
 @documentation{
-    system location definition
-}
-type structure_sysloc = {
-    "campus"     ? string
-    "building"   ? string
-    "city"       ? string
-    "country"  ? string
-    "continent"  ? string
-    "room"       ? string
-    "bunker"     ? string
-    "region"     ? string
-    "dns_search_domains" ? string[]
-    "location" ? string
-};
-
-@documentation{
     System benchmark results
     benchmarks is used to hold the performance benchmark for the machine
     i.e. HEPSpec06 score
@@ -268,9 +243,7 @@ type structure_hardware = {
     "cpu"          ? structure_cpu[]
     "ram"          ? structure_ram[]
     "cards"        ? structure_cards
-    "rack"     ? structure_rack
     "console"      ? structure_console
-    "sysloc"       ? structure_sysloc
     "nodename"     ? string
     "benchmarks" ? structure_benchmark
     "sensors" ? structure_sensor_types
@@ -280,6 +253,8 @@ type structure_hardware = {
     "procured"     ? type_isodate
     # Obsolete field, use the appropriate "cards" sub-field instead!!
     "harddisks"    ? structure_raidport{}
+    # Aquilon-specific resources
+    include structure_hardware_aquilon
 };
 
 # TODO is it ok to define variables in declartaion templates?

--- a/quattor/types/hardware.pan
+++ b/quattor/types/hardware.pan
@@ -56,7 +56,7 @@ type structure_nic = {
 type structure_rack = {
     "name" : string
     "column" : string
-    "room" : string
+    "room" ? string
     "row" : string
 };
 
@@ -234,6 +234,7 @@ type structure_sysloc = {
     "campus"     ? string
     "building"   ? string
     "city"       ? string
+    "country"  ? string
     "continent"  ? string
     "room"       ? string
     "bunker"     ? string

--- a/quattor/types/system.pan
+++ b/quattor/types/system.pan
@@ -25,7 +25,7 @@ include 'components/network/core-schema';
 include 'quattor/blockdevices';
 include 'quattor/filesystems';
 include 'quattor/types/aii';
-include 'quattor/types/aquilon';
+include 'quattor/types/aquilon/system';
 include 'quattor/types/grid';
 include 'quattor/types/hardware';
 include 'quattor/types/os';


### PR DESCRIPTION
As explained in https://github.com/quattor/aquilon/issues/90, current schema is not consistent with plenary templates generated by Aquilon (1.12.58). This PR reconciles them, preserving backward compatibility

This PR also improves the schema layout by factoring out of the base file hardware resources specific to Aquilon. And all the properties mandatory in the Aquilon DB and passed by the broker into the generated templates have been defined as mandatory.