### PR TITLE
Revert /system/archetype/os changes

### DIFF
--- a/quattor/types/aquilon.pan
+++ b/quattor/types/aquilon.pan
@@ -58,6 +58,7 @@ type structure_archetype = {
     "name"          : string # e.g. "aquilon"
     @{ Details of operating system as defined by aquilon broker }
     "os"            ? structure_archetype_os
+    "model"         ? string # e.g. "4.0.1-x86_64"
     "filesystem-layout" ? string with if_exists("archetype/filesystem-layouts/" + SELF) != ""
     "archlist"      ? string[] # e.g. fs sysname list for model,
                                # "x86_64.linux.2.6.glibc.2.3", "amd64.linux.2.4.glibc.2.3", ...

--- a/quattor/types/aquilon.pan
+++ b/quattor/types/aquilon.pan
@@ -46,7 +46,7 @@ type structure_cluster = {
     "node_index" ? long(0..)
     "max_hosts" ? long(0..)
 };
- 
+
 type structure_archetype = {
     "name"          : string # e.g. "aquilon"
     "os"            ? string # e.g. "linux"
@@ -145,7 +145,7 @@ type structure_security = {
     "class"         : string with if_exists("archetype/security/" + SELF) != ""
     "svcwhitelist"  ? list
 };
- 
+
 type structure_system_aquilon = {
     "advertise_status" ? boolean
     "archetype"     ? structure_archetype

--- a/quattor/types/aquilon.pan
+++ b/quattor/types/aquilon.pan
@@ -46,18 +46,10 @@ type structure_cluster = {
     "node_index" ? long(0..)
     "max_hosts" ? long(0..)
 };
-
-type structure_archetype_os = {
-    @{ Name of OS (i.e. aq --osname or aqdb OperatingSystem.name) }
-    "name" : string
-    @{ Version of OS (i.e. aq --osversion or aqdb OperatingSystem.version) }
-    "version" : string
-};
-
+ 
 type structure_archetype = {
     "name"          : string # e.g. "aquilon"
-    @{ Details of operating system as defined by aquilon broker }
-    "os"            ? structure_archetype_os
+    "os"            ? string # e.g. "linux"
     "model"         ? string # e.g. "4.0.1-x86_64"
     "filesystem-layout" ? string with if_exists("archetype/filesystem-layouts/" + SELF) != ""
     "archlist"      ? string[] # e.g. fs sysname list for model,
@@ -153,7 +145,7 @@ type structure_security = {
     "class"         : string with if_exists("archetype/security/" + SELF) != ""
     "svcwhitelist"  ? list
 };
-
+ 
 type structure_system_aquilon = {
     "advertise_status" ? boolean
     "archetype"     ? structure_archetype


### PR DESCRIPTION
These changes were included as part of #142, but were not necessary for that use-case. The impact of these changes was underestimated and as the new types appear to be unused in the community the change should be reverted ASAP.

Fixes #179.
Fixes quattor/aquilon#93.