### PR TITLE
/functions/filesystem: fix compatibility with panc 10.7

### DIFF
--- a/quattor/functions/filesystem.pan
+++ b/quattor/functions/filesystem.pan
@@ -16,7 +16,7 @@ function num_of_harddisks = {
 };
 
 @documentation{
-    desc = returns the disk where grub must be installed
+    desc = returns the disk where grub must be installed to or undef if none is found
     arg = none
 }
 function boot_disk = {


### PR DESCRIPTION
- In panc 10.7, null is no longer considered an undefined value (see https://github.com/quattor/pan/pull/175)