### PR TITLE
pan/types: fix incorrect regexp for linux_capability

### DIFF
--- a/pan/types.pan
+++ b/pan/types.pan
@@ -1000,4 +1000,4 @@ type cpu_architecture = string with match (SELF, '^(i386|ia64|x86_64|sparc|aarch
 @documentation{
     desc = Linux capabilities, see CAPABILITIES(7)
 }
-type linux_capability = string with match(SELF, '^CAP_[[:upper:]_]+$');
+type linux_capability = string with match(SELF, '^CAP_[A-Z_]+$');


### PR DESCRIPTION
- `[:upper:]` replaced by `[A-Z]`

Fixes #186