### PR TITLE
types: aquilon: add new structure_entitlements in the system parameters

### DIFF
--- a/quattor/types/aquilon/system.pan
+++ b/quattor/types/aquilon/system.pan
@@ -149,6 +149,20 @@ type structure_security = {
     "svcwhitelist"  ? list
 };
 
+type structure_entitlement_user = {
+    "type"          : string
+    "value"         : valid_user
+};
+
+type structure_entitlement_eon_id = {
+    "value"         : long
+};
+
+type structure_entitlements = {
+    "eon_id"        ? structure_entitlement_eon_id[]
+    "user"          ? structure_entitlement_user[]
+};
+
 # All resources in this structure must be optional so that the
 # schema can be used by non Aquilon sites
 type structure_system_aquilon = {
@@ -164,6 +178,7 @@ type structure_system_aquilon = {
     "eon_ids"       ? long[]
     "eon_id_maps"   ? nlist
     "owner_eon_id"  ? long
+    "entitlements"  ? structure_entitlements{}
     "provides"      ? nlist
     "services"      ? structure_services{}
     "personality"   ? structure_personality


### PR DESCRIPTION
A new entitlement system is being added to the Aquilon broker. It will
allow to set entitlements of a given type (for instance, 'login' or
'root') and enable them by host, cluster, personality, archetype or
Grn/EonID.

These new entitlements need to be stored to be picked up by the
templates in order to act on them, and this is why the
structure_entitlements is being added: we will now have in the
structure_system_aquilon structure an "entitlements" dictionary that
will use the entitlements type as key, and a structure_entitlements
as value. In there, we will find entitlements per-EonID or per-user.
In the later case, the user type (also being added to the broker)
will also be mentioned (as to, for instance, insure some activities
are only being entitled for system users).