### PR TITLE
test_templates: Use a single version of schema for ceph and ssh

### DIFF
--- a/test_templates.sh
+++ b/test_templates.sh
@@ -400,6 +400,9 @@ sed -i "/.*components\/spma\/\(apt\|ips\).*/d" build_temp/test.pan
 # Only test default schema version of ceph component
 sed -i "/.*components\/ceph\/v[1-9][0-9]*\/.*/d" build_temp/test.pan
 
+# Only test default schema version of ssh component
+sed -i "/.*components\/ssh\/schema-.*/d" build_temp/test.pan
+
 # try to compile it
 output=`panc --output-dir build_temp --include-path .:build_temp build_temp/test.pan 2>&1`
 

--- a/test_templates.sh
+++ b/test_templates.sh
@@ -397,7 +397,8 @@ sed -i "/.*metaconfig\/ganesha\/fsal.*/d" build_temp/test.pan
 # only spma yum
 sed -i "/.*components\/spma\/\(apt\|ips\).*/d" build_temp/test.pan
 
-
+# Only test default schema version of ceph component
+sed -i "/.*components\/ceph\/v[1-9][0-9]*\/.*/d" build_temp/test.pan
 
 # try to compile it
 output=`panc --output-dir build_temp --include-path .:build_temp build_temp/test.pan 2>&1`


### PR DESCRIPTION
Avoids issues with duplicate type definitions from multi-version schema which have been causing tests to fail on this repository.