### PR TITLE
Allow the caf_service_action to be used by multiple components

### DIFF
--- a/quattor/types/component.pan
+++ b/quattor/types/component.pan
@@ -2,6 +2,12 @@ declaration template quattor/types/component;
 
 include 'quattor/functions/validation';
 
+type caf_service_actions = string with choice(
+    'restart',
+    'reload',
+    'stop_sleep_start',
+);
+
 type structure_component_dependency = {
     "pre"       ? string[] with is_component_list(SELF)
     "post"      ? string[] with is_component_list(SELF)


### PR DESCRIPTION
This will be reverted during the release process unless the corresponding change is made to ncm-metaconfig in configuration-modules-core.