### PR TITLE
Aquilon schema: location attribute requirements relaxed

### DIFF
--- a/quattor/types/aquilon/hardware.pan
+++ b/quattor/types/aquilon/hardware.pan
@@ -20,17 +20,20 @@ type structure_rack = {
 
 @documentation{
     system location definition
+    For clusters (and thus for virtual machines in the cluster),
+    no attribute is mandatory. The only requirement is that one is
+    defined.
 }
 type structure_sysloc = {
-    "building"   : string
+    "building"   ? string
     "campus"     ? string
-    "city"       : string
-    "country"    : string
-    "continent"  : string
-    "room"       : string
+    "city"       ? string
+    "country"    ? string
+    "continent"  ? string
+    "room"       ? string
     "bunker"     ? string
     "region"     ? string
-};
+} with ( length(SELF) > 0);
 
 # All the resources in this type must be optional for
 # the schema to remain usable by non-Aquilon users


### PR DESCRIPTION
In previous change, several location-related attributes were made
mandatory as they are required for a machine object. But they
are not for a cluster, with the consequence that they may not be defined
for the virtual machines hosted by the cluster.