### PR TITLE
hardware types: add options structure

### DIFF
--- a/quattor/types/hardware.pan
+++ b/quattor/types/hardware.pan
@@ -300,14 +300,14 @@ final variable ENC_TYPES = '^(blade|dumb|hypervisor)$';
 }
 type structure_enclosure = {
     "type"          : string with match(SELF, ENC_TYPES)
-                        || error("enclosure type must be one of: " + ENC_TYPES)
+    || error("enclosure type must be one of: " + ENC_TYPES)
     "children"      ? string[1..] with is_profile_list(SELF)
     "maxchildren"   ? long
 } with {
     if (exists(SELF['children']) && exists(SELF['maxchildren'])) {
         SELF['maxchildren'] >= length(SELF['children'])
         || error("enclosure has too many children, max is " +
-            to_string(SELF['maxchildren']));
+        to_string(SELF['maxchildren']));
     } else {
         true;
     };

--- a/quattor/types/hardware.pan
+++ b/quattor/types/hardware.pan
@@ -244,6 +244,15 @@ type structure_bios = {
 };
 
 @documentation{
+    Configuration settings
+}
+type structure_hw_options = {
+    @{Signal to the hardware management platform that all directly attached
+      disks should be encrypted.}
+    "encrypt_disks" ? boolean
+};
+
+@documentation{
     Hardware definition
 }
 type structure_hardware = {
@@ -258,6 +267,8 @@ type structure_hardware = {
     "sensors" ? structure_sensor_types
     @{Date at which the hardware support runs out.}
     "support"      ? type_isodate
+    @{Optional configuration settings}
+    "options"      ? structure_hw_options
     @{Date at which the hardware is procured.}
     "procured"     ? type_isodate
     # Obsolete field, use the appropriate "cards" sub-field instead!!


### PR DESCRIPTION
Add a new attribute to the hardware structure to allow the configuration
of optional hardware settings, such as disk encryption.