### PR TITLE
quattor/functions/hardware: Provide function to get max_threads for all CPUs

### DIFF
--- a/quattor/functions/hardware.pan
+++ b/quattor/functions/hardware.pan
@@ -1,4 +1,3 @@
-
 declaration template quattor/functions/hardware;
 
 
@@ -6,34 +5,33 @@ declaration template quattor/functions/hardware;
 # specifified as a HW template (string) or a HW configuration (nlist)².
 function get_num_of_cores = {
     if ( ARGC == 0 ) {
-      hw_config = value('/hardware');
+        hw_config = value('/hardware');
     } else if ( ARGC == 1 ) {
-      if ( is_nlist(ARGV[0]) ) {
-        hw_config = ARGV[0];
-      } else if ( is_string(ARGV[0]) ) {
-        hw_config = create(ARGV[0]);
-      } else {
-        error(format('Invalid argument type (%s)',to_string(ARGV[0])));
-      }
-    } else {
-      error(format('get_num_of_cores requires 0 or 1 argument (%s specified)',ARGC));
-    };
-    debug(format('%s: HW config = %s',OBJECT,to_string(hw_config)));
-
-    if ( is_defined(hw_config['cpu']) && (length(hw_config['cpu']) > 0) ) {
-      cores = 0;
-      foreach (i;cpu;hw_config['cpu']) {
-        if ( is_defined(cpu['cores']) ) {
-          cores = cores + cpu['cores'];
+        if ( is_dict(ARGV[0]) ) {
+            hw_config = ARGV[0];
+        } else if (is_string(ARGV[0])) {
+            hw_config = create(ARGV[0]);
         } else {
-          cores = cores + 1;
-        };
-      };
-      debug(format('%s: num of CPUs=%d, num of cores=%d',OBJECT,length(hw_config['cpu']),cores));
+            error('Invalid argument type (%s)', to_string(ARGV[0]));
+        }
     } else {
-      error('Invalid hardware configuration (no CPU defined)');
+        error('get_num_of_cores requires 0 or 1 argument (%s specified)', ARGC);
+    };
+    debug('%s: HW config = %s', OBJECT, hw_config);
+
+    if (is_defined(hw_config['cpu']) && (length(hw_config['cpu']) > 0)) {
+        cores = 0;
+        foreach (i; cpu; hw_config['cpu']) {
+            if (is_defined(cpu['cores'])) {
+                cores = cores + cpu['cores'];
+            } else {
+                cores = cores + 1;
+            };
+        };
+        debug('%s: num of CPUs=%d, num of cores=%d', OBJECT, length(hw_config['cpu']), cores);
+    } else {
+        error('Invalid hardware configuration (no CPU defined)');
     };
 
     cores;
 };
-

--- a/quattor/functions/hardware.pan
+++ b/quattor/functions/hardware.pan
@@ -1,10 +1,11 @@
 declaration template quattor/functions/hardware;
 
+
 @documentation{
-    descr = Returns the number of cores on the current machine or another machine specifified as a HW template (string) or a HW configuration (nested dict).
-    arg = A dict or string (optional) specifying the source of the hardware configuration.
+    descr = Returns the hardware tree of the current machine or another machine
+    arg = A HW template (string) or a HW configuration (nested dict) to use as a source of hardware configuration (optional)
 }
-function get_num_of_cores = {
+function get_hw_config = {
     if ( ARGC == 0 ) {
         hw_config = value('/hardware');
     } else if ( ARGC == 1 ) {
@@ -16,23 +17,76 @@ function get_num_of_cores = {
             error('Invalid argument type (%s)', to_string(ARGV[0]));
         }
     } else {
-        error('get_num_of_cores requires 0 or 1 argument (%s specified)', ARGC);
+        error('%s requires 0 or 1 argument (%s specified)', FUNCTION, ARGC);
     };
     debug('%s: HW config = %s', OBJECT, hw_config);
+    hw_config;
+};
+
+
+@documentation{
+    descr = Returns the number of cores and the maximum number of hardware threads on the current or another machine as a dict
+    arg = A HW template (string) or a HW configuration (nested dict) to use as a source of hardware configuration (optional)
+}
+function get_num_of_cores_max_threads = {
+    if ( ARGC == 1 ) {
+        hw_config = get_hw_config(ARGV[0]);
+    } else {
+        hw_config = get_hw_config();
+    };
 
     if (is_defined(hw_config['cpu']) && (length(hw_config['cpu']) > 0)) {
-        cores = 0;
+        result = dict(
+            'cores', 0,
+            'threads', 0,
+        );
         foreach (i; cpu; hw_config['cpu']) {
-            if (is_defined(cpu['cores'])) {
-                cores = cores + cpu['cores'];
+            if (is_defined(cpu['max_threads'])) {
+                result['threads'] = result['threads'] + cpu['max_threads'];
             } else {
-                cores = cores + 1;
+                result['threads'] = result['threads'] + 1;
+            };
+            if (is_defined(cpu['cores'])) {
+                result['cores'] = result['cores'] + cpu['cores'];
+            } else {
+                result['cores'] = result['cores'] + 1;
             };
         };
         debug('%s: num of CPUs=%d, num of cores=%d', OBJECT, length(hw_config['cpu']), cores);
     } else {
         error('Invalid hardware configuration (no CPU defined)');
     };
+    result;
+};
 
-    cores;
+
+@documentation{
+    descr = Returns the number of cores for the supplied hardware config, or the current machine if no argument is passed.
+    arg = A HW template (string) or a HW configuration (nested dict) to use as a source of hardware configuration (optional)
+}
+function get_num_of_cores = {
+    if ( ARGC == 1 ) {
+        hw_config = get_hw_config(ARGV[0]);
+    } else {
+        hw_config = get_hw_config();
+    };
+
+    d = get_num_of_cores_max_threads(hw_config);
+    d['cores'];
+};
+
+
+@documentation{
+    descr = Returns the maximum number of hardware threads for the supplied hardware config, or the current machine if no argument is passed.
+    arg = A HW template (string) or a HW configuration (nested dict) to use as a source of hardware configuration (optional)
+}
+function get_num_of_max_threads = {
+    if ( ARGC == 1 ) {
+        hw_config = get_hw_config(ARGV[0]);
+    } else {
+        hw_config = get_hw_config();
+    };
+
+    d = get_num_of_cores_max_threads(hw_config);
+    d['threads'];
 };

--- a/quattor/functions/hardware.pan
+++ b/quattor/functions/hardware.pan
@@ -1,8 +1,9 @@
 declaration template quattor/functions/hardware;
 
-
-# Returns the number of cores on the current machine or another machine
-# specifified as a HW template (string) or a HW configuration (nlist)².
+@documentation{
+    descr = Returns the number of cores on the current machine or another machine specifified as a HW template (string) or a HW configuration (nested dict).
+    arg = A dict or string (optional) specifying the source of the hardware configuration.
+}
 function get_num_of_cores = {
     if ( ARGC == 0 ) {
         hw_config = value('/hardware');


### PR DESCRIPTION
Much of the configuration of our compute systems relies on knowing both the number of cores and threads available on any given host and as such a number of home-grown "quick fixes" have developed for obtaining this information. This is an attempt to provide the functionality upstream with the hope of removing out local kludges in future.