### PR TITLE
Add string type for an octal mode/mask

### DIFF
--- a/pan/types.pan
+++ b/pan/types.pan
@@ -1042,3 +1042,9 @@ type string_search_path = string_trimmed with {
     if (dot_count > 1) error('The search path "%s" contains more than one reference to the working directory.', SELF);
     true;
 };
+
+
+@documentation{
+    desc = string type to store a valid mode/mask in octal
+}
+type type_octal_mode = string with to_long(SELF, 8) >= 0 && to_long(SELF, 8) <= 07777;


### PR DESCRIPTION
As suggested by @gombasg, just parse it numerically to fit in the interval [0,07777].

@ned21 as requested in quattor/configuration-modules-core#1396