### PR TITLE
panc 10.7 is now the minimum supported compiler

### DIFF
--- a/quattor/client/pan_compiler.pan
+++ b/quattor/client/pan_compiler.pan
@@ -9,7 +9,7 @@ values = string (version number)
 default = 10.3-1
 required = no
 }
-variable PANC_DEFAULT_VERSION ?= '10.3-1';
+variable PANC_DEFAULT_VERSION ?= '10.7-1';
 
 '/software/packages' = pkg_repl('panc', PANC_DEFAULT_VERSION, 'noarch');
 


### PR DESCRIPTION
Language features such as choice (10.4) and relative prefix statements (10.7) are now commonly used across the codebase.