### PR TITLE
El8 support

### DIFF
--- a/quattor/aii/ks/variants/el8.pan
+++ b/quattor/aii/ks/variants/el8.pan
@@ -1,0 +1,34 @@
+# Template containing OS configuration and default values.
+
+template quattor/aii/ks/variants/el8;
+
+# Remove deprecated options
+prefix "/system/aii/osinstall/ks";
+"mouse" = null;
+"langsupport" = null;
+"packages_args" = list("--ignoremissing");
+
+"end_script" = "%end";  # TODO: remove - no longer used
+"part_label" = true;
+"volgroup_required" = false;
+"lvmforce" = true;
+
+# el8
+"version" = "19.31";
+"bootproto" = "static";
+"enable_sshd" = true;
+"cmdline" = true;
+
+"logging/method" = 'bash';
+"logging/protocol" = 'tcp';
+
+# rhel
+"eula" = true;
+# deal with optional repository
+"packagesinpost" ?= true;
+
+prefix "/system/aii/nbp/pxelinux";
+"setifnames" = true;
+
+# use updates to fix the reverseproxy issue
+#"updates" = "http://some.server/updates-rhel7rc-timeout.img";

--- a/quattor/client/rpms.pan
+++ b/quattor/client/rpms.pan
@@ -15,22 +15,26 @@ variable QUATTOR_INSTALL_CDISPD ?= true;
 
 include 'quattor/client/version';
 
+# Add ncm-spma from the its config template to ensure we use the appropriate version
+include 'components/spma/config';
+
 '/software/packages' = {
     # python-elementtree is required by YUM on SL5 but not listed as a dependency
     # of any other package
     if ( OS_VERSION_PARAMS['majorversion'] == '5' ) {
-      pkg_repl('python-elementtree');
+        pkg_repl('python-elementtree');
     };
 
     # Quattor
-    pkg_repl('ncm-ncd',QUATTOR_PACKAGES_VERSION,'noarch');
-    pkg_repl('ncm-query',QUATTOR_PACKAGES_VERSION,'noarch');
-    pkg_repl('ncm-spma',QUATTOR_PACKAGES_VERSION,'noarch');
+    pkg_repl('ncm-ncd', QUATTOR_PACKAGES_VERSION, 'noarch');
+    pkg_repl('ncm-query', QUATTOR_PACKAGES_VERSION, 'noarch');
 
     if ( QUATTOR_INSTALL_CDISPD ) {
         pkg_repl('cdp-listend', QUATTOR_PACKAGES_VERSION, 'noarch');
         pkg_repl('ncm-cdispd', QUATTOR_PACKAGES_VERSION, 'noarch');
     };
+
+    debug('ncm-spma version=%s', unescape(key(SELF[escape('ncm-spma')], 0)));
 
     SELF;
 };


### PR DESCRIPTION
- Add the missing template for AII KS
- Ensure that the `ncm-spma` version used is the one configured, if the default version was changed (.e.g. for testing)