### PR TITLE
New type for strings which represent lists of email addresses

### DIFF
--- a/pan/types.pan
+++ b/pan/types.pan
@@ -820,8 +820,9 @@ function is_email = {
     desc = require a comma-separated list of email addresses
 }
 function is_email_list = {
-    if (ARGC != 1 || !is_string(ARGV[0]))
+    if (ARGC != 1 || !is_string(ARGV[0])) {
         error("usage: is_email_list(string)");
+    };
 
     foreach(i; email; split(",", SELF)) {
         if (!is_email(email)) {
@@ -1003,10 +1004,10 @@ function is_absolute_file_path = {
     path = ARGV[0];
 
     if (match(path, '/$')) {
-        error(format('Path "%s" does not refer to a file, it has an invalid trailing slash', path));
+        error('Path "%s" does not refer to a file, it has an invalid trailing slash', path);
     };
     if (match(path, '^[^/]')) {
-        error(format('Path "%s" is not absolute, leading slash is missing', path));
+        error('Path "%s" is not absolute, leading slash is missing', path);
     };
 
     true;

--- a/pan/types.pan
+++ b/pan/types.pan
@@ -816,6 +816,24 @@ function is_email = {
     true;
 };
 
+@documentation{
+    desc = require a comma-separated list of email addresses
+}
+function is_email_list = {
+    if (ARGC != 1 || !is_string(ARGV[0]))
+        error("usage: is_email_list(string)");
+
+    foreach(i; email; split(",", SELF)) {
+        if (!is_email(email)) {
+            error('is_email_list: email %s is not valid.', email);
+        };
+    };
+    true;
+};
+
+type type_email_list = string with {
+    is_email_list(SELF);
+};
 
 type type_email = string with {
     is_email(SELF);


### PR DESCRIPTION
Some configurations require comma-separated email addresses. This type is useful to validate those.

THIS SOFTWARE IS CONTRIBUTED SUBJECT TO THE TERMS OF THE APACHE LICENSE, V.2.0. YOU MAY OBTAIN A COPY OF THE LICENSE AT https://www.apache.org/licenses/LICENSE-2.0.
THIS SOFTWARE IS LICENSED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE AND ANY WARRANTY OF NON-INFRINGEMENT, ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. THIS SOFTWARE MAY BE REDISTRIBUTED TO OTHERS ONLY BY EFFECTIVELY USING THIS OR ANOTHER EQUIVALENT DISCLAIMER IN ADDITION TO ANY OTHER REQUIRED LICENSE TERMS.