### PR TITLE
Fix type of ntpd_tinker_options/step #219

### DIFF
--- a/components/ntpd/schema.pan
+++ b/components/ntpd/schema.pan
@@ -90,7 +90,7 @@ type ntpd_tinker_options = {
     "freq" ? long
     "huffpuff" ? long
     "panic" ? long
-    "step" ? long
+    "step" ? double
     "stepout" ? long
 };
 


### PR DESCRIPTION
The step value is represented in seconds.
See tinker definition in https://www.ntp.org/documentation/4.2.8-series/miscopt/