### PR TITLE
add bootmode option to provide support for uefi

### DIFF
--- a/quattor/types/hardware.pan
+++ b/quattor/types/hardware.pan
@@ -241,6 +241,7 @@ type structure_benchmark = {
 type structure_bios = {
     "version" : string
     "releasedate" : string
+    "bootmode" ? choice('uefi', 'bios')
 };
 
 @documentation{


### PR DESCRIPTION
bootmode with a choice of "uefi" or "bios" added to the bios subtree