### PR TITLE
types/hardware: Add HEPScore23 and deprecate HS06

### DIFF
--- a/quattor/types/hardware.pan
+++ b/quattor/types/hardware.pan
@@ -220,15 +220,15 @@ type structure_console = extensible {
 
 @documentation{
     System benchmark results
-    benchmarks is used to hold the performance benchmark for the machine
-    i.e. HEPSpec06 score
-    this might be used to scale things such as the wall time
-    example of using this might be :
-    variable CONDOR_WN_SCALING_FACTOR = value('/hardware/benchmarks/hepspec06')
-          / ( 4 * get_num_of_cores()) ;
+
+    Benchmarks is used to hold the performance benchmark for the machine e.g. HEPScore23.
+    These can be used to scale things such as the wall time of jobs, an example of using this might be:
+
+    variable CONDOR_WN_SCALING_FACTOR = value('/hardware/benchmarks/hepscore23') / ( 4 * get_num_of_cores());
 }
 type structure_benchmark = {
-    "hepspec06" ? double
+    "hepspec06" ? double with { deprecated(0, "HEPSPEC06 has been superceded by HEPScore23"); true; }
+    "hepscore23" ? double
     @{unit: Gflops}
     "HPL" ? double
     @{unit: MB/s TRIAD}


### PR DESCRIPTION
HEPScore23 started to replace HS06 from April 2023 onward and is now the primary benchmark used by WLCG.

See also: https://w3.hepix.org/benchmarking.html