### PR TITLE
Revert "AII templates for tag 24.10.0-rc2"

### DIFF
--- a/quattor/aii/config.pan
+++ b/quattor/aii/config.pan
@@ -1,0 +1,56 @@
+################################################################################
+# #
+# Software subject to following license(s):
+#   Apache 2 License (http://www.opensource.org/licenses/apache2.0)
+#   Copyright (c) Responsible Organization
+#
+
+# #
+# Current developer(s):
+#   Luis Fernando Muñoz Mejías <Luis.Munoz@UGent.be>
+#   Ronald Starink <ronalds@nikhef.nl>
+#
+
+# #
+# Author(s): Michel Jouvin, Ben Jones, Gabor Gombas, Nick Williams, Stijn De Weirdt
+#
+
+# #
+# server, 24.10.0-rc1, rc1_1, Tue Oct 08 2024
+#
+#
+# This file is the standard aii configuration. It only performs some
+# validations, combines information that is already available, and
+# set sensible default values.
+#
+# This file should NOT contain any site or platform customization.
+#
+################################################################################
+
+unique template quattor/aii/config;
+
+include 'quattor/functions/network';
+include 'quattor/functions/filesystem';
+include 'quattor/aii/schema';
+
+# First include AII site configuration, if any
+variable AII_CONFIG_SITE ?= undef;
+include if_exists(to_string(AII_CONFIG_SITE));
+
+# For convenience
+variable AII_DOMAIN ?= value('/system/network/domainname');
+variable AII_HOSTNAME ?= value('/system/network/hostname');
+
+# Configure AII plugins
+variable AII_OSINSTALL_GEN ?= "quattor/aii/ks/config";
+variable AII_NBP_GEN ?= "quattor/aii/pxelinux/config";
+
+# Including the KS generator or equivalent
+include AII_OSINSTALL_GEN;
+# Including the PXE generator or equivalent
+include AII_NBP_GEN;
+
+# Include DHCP configuration
+# Set AII_DHCP_CONFIG to null if DHCP configuratio is managed outside AII
+variable AII_DHCP_CONFIG ?= "quattor/aii/dhcp/config";
+include AII_DHCP_CONFIG;

--- a/quattor/aii/rpms.pan
+++ b/quattor/aii/rpms.pan
@@ -1,0 +1,25 @@
+# #
+# Software subject to following license(s):
+#   Apache 2 License (http://www.opensource.org/licenses/apache2.0)
+#   Copyright (c) Responsible Organization
+#
+
+# #
+# Current developer(s):
+#   Luis Fernando Muñoz Mejías <Luis.Munoz@UGent.be>
+#   Ronald Starink <ronalds@nikhef.nl>
+#
+
+# #
+# Author(s): Michel Jouvin, Ben Jones, Gabor Gombas, Nick Williams, Stijn De Weirdt
+#
+
+# #
+# server, 24.10.0-rc1, rc1_1, Tue Oct 08 2024
+#
+
+# Template adding aii-server rpm to the configuration
+
+unique template quattor/aii/rpms;
+
+"/software/packages" = pkg_repl("aii-server", "24.10.0-rc1_1", "noarch");

--- a/quattor/aii/schema.pan
+++ b/quattor/aii/schema.pan
@@ -1,0 +1,22 @@
+# #
+# Software subject to following license(s):
+#   Apache 2 License (http://www.opensource.org/licenses/apache2.0)
+#   Copyright (c) Responsible Organization
+#
+
+# #
+# Current developer(s):
+#   Luis Fernando Muñoz Mejías <Luis.Munoz@UGent.be>
+#   Ronald Starink <ronalds@nikhef.nl>
+#
+
+# #
+# Author(s): Michel Jouvin, Ben Jones, Gabor Gombas, Nick Williams, Stijn De Weirdt
+#
+
+# #
+# server, 24.10.0-rc1, rc1_1, Tue Oct 08 2024
+#
+unique template quattor/aii/schema;
+
+


### PR DESCRIPTION
Restore the AII templates deleted by a failure of the releaser script during the RC2 build.

This reverts commit 0692641c6c2ceb63f725d55964f4c36809f749d0.