### PR TITLE
physdevices: RAID controllers can have PCI details

### DIFF
--- a/quattor/physdevices.pan
+++ b/quattor/physdevices.pan
@@ -17,14 +17,3 @@ type structure_raidport = {
     # between device name and partition number (e.g. HP SmartArray)
     "part_prefix" : string = ''
 };
-
-@documentation{
-    Structure modelling a RAID controller
-}
-type structure_raid = {
-    include structure_annotation
-    "bbu" ? boolean
-    "numberports" : long (1..)
-    "cache" ? long # In MB
-    "ports" : structure_raidport{}
-} with length (SELF["ports"]) <= SELF["numberports"];

--- a/quattor/types/hardware.pan
+++ b/quattor/types/hardware.pan
@@ -84,6 +84,18 @@ type structure_pci = {
     "class"  ? long
 };
 
+@documentation{
+    Structure modelling a RAID controller
+}
+type structure_raid = {
+    include structure_annotation
+    "bbu" ? boolean
+    "numberports" : long (1..)
+    "cache" ? long # In MB
+    "ports" : structure_raidport{}
+    "pci" ? structure_pci
+} with length (SELF["ports"]) <= SELF["numberports"];
+
 @docmentation{
     The Infiniband hardware address is a series of twenty bytes encoded as hex values
     and separated with a colon or a hyphen.  Within a value you must


### PR DESCRIPTION
The `boss-n1` card in template-library-standard already does, which currently makes it unusable.