### PR TITLE
New option to allow override of how fstab entries get created.

### DIFF
--- a/quattor/filesystems.pan
+++ b/quattor/filesystems.pan
@@ -74,4 +74,6 @@ type structure_filesystem = {
     "ksfsformat" ? boolean
     @{ When defined and false, AII will ignore this filesystem }
     "aii" ? boolean
+    @{ When defined and true, the device path will be used in fstab for the mount point, even if a UUID is available.}
+    "mount_devpath" ? boolean
 };


### PR DESCRIPTION
New option to override how fstab entries get created. For vols such as vxvm, using uuid does not work. it should always be devpath. This will allow to control this.
ncm-lib-blockdevices code has been updated to check for this option (https://github.com/quattor/ncm-lib-blockdevices/pull/111), if defined and true, it will ignore uuid and always use devpath when creating entries in fstab. Requires ncm-lib-blockdevices >=25.x
